### PR TITLE
Add CORS middleware for web tool compatibility

### DIFF
--- a/App/__main__.py
+++ b/App/__main__.py
@@ -5,6 +5,7 @@ import sys
 import click
 import httpx
 import uvicorn
+from starlette.middleware.cors import CORSMiddleware
 
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler
@@ -90,8 +91,18 @@ def main(host, port):
         server = A2AStarletteApplication(
             agent_card=agent_card, http_handler=request_handler
         )
+        
+        # Add CORS middleware to handle cross-origin requests
+        app = server.build()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],  # Allow all origins for development - restrict in production
+            allow_credentials=True,
+            allow_methods=["*"],  # Allow all HTTP methods
+            allow_headers=["*"],  # Allow all headers
+        )
 
-        uvicorn.run(server.build(), host=host, port=port)
+        uvicorn.run(app, host=host, port=port)
         # --8<-- [end:DefaultRequestHandler]
 
     except MissingAPIKeyError as e:


### PR DESCRIPTION
## Summary
- Add CORS (Cross-Origin Resource Sharing) middleware to fix web tool compatibility
- Resolves browser CORS errors when testing agent from web interfaces
- Enables cross-origin requests for A2A protocol communication

## Problem Solved
Web-based A2A testing tools were encountering CORS errors when trying to connect to the agent. Modern browsers block cross-origin requests by default unless the server explicitly allows them via CORS headers.

## Technical Changes
- **Import**: Added `CORSMiddleware` from Starlette
- **Configuration**: Applied permissive CORS policy:
  - ✅ All origins allowed (`allow_origins=["*"]`)
  - ✅ All HTTP methods allowed (`allow_methods=["*"]`)
  - ✅ All headers allowed (`allow_headers=["*"]`)
  - ✅ Credentials enabled (`allow_credentials=True`)

## Testing Results
✅ **CORS Preflight**: OPTIONS requests return proper allow headers  
✅ **Cross-Origin POST**: Requests include `access-control-allow-origin: *`  
✅ **Agent Functionality**: All A2A endpoints work with CORS headers  
✅ **Local Verification**: Tested with simulated cross-origin requests  

## Security Considerations
- Current configuration is permissive for maximum compatibility
- Suitable for development and testing environments
- Production deployments may want to restrict `allow_origins` to specific domains
- No sensitive data exposure - CORS only affects browser enforcement

## Files Changed
- `App/__main__.py`: Added CORS middleware configuration

## Testing Instructions
1. Test with web-based A2A tool - CORS errors should be resolved
2. Verify preflight OPTIONS requests work: `curl -X OPTIONS -H "Origin: https://example.com" [agent-url]`
3. Confirm cross-origin POST requests succeed with proper headers

🤖 Generated with [Claude Code](https://claude.ai/code)